### PR TITLE
Missing capability string

### DIFF
--- a/lang/en/atto_multilang2.php
+++ b/lang/en/atto_multilang2.php
@@ -28,3 +28,4 @@ $string['highlight_desc'] = 'Visually highlight the multi-language content delim
 $string['customcss'] = 'CSS for delimiters';
 $string['customcss_desc'] = "<br>CSS used to highlight the multi-language content delimiters.
 <p><b>Attention:</b> just put the CSS BODY RULES, excluding the selectors, just as it appears in the default value.</p>";
+$string['multilang2:viewlanguagemenu'] = 'View language menu in the editor';


### PR DESCRIPTION
Debugging message on "roles" page breaks behat tests for other plugins if atto_multilang2 is installed
