### PR TITLE
Rephrased Gherkin for Moodle 3.4 fixes #31.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The plugin is developed to work with [Iñaki Arenaza's multilang2 filter](https:
 The latest release is v1.10 (build 2019110600) for Moodle 3.6 and 3.7.
 
 ## Changes from v1.9
- - The Privacy Api has been implemented so that this plugin complies with the new General Data Protection Regulation, effective as of May 25, 2018.
+ - The Privacy Api has been implemented so that this plugin complies with the new [General Data Protection Regulation](https://eugdpr.org/) (GDPR), effective as of May 25, 2018.
 
 ## Changes from v1.8
  - Added Grunt support files. No we can check Moodle Javascript coding guidelines and minify the plugin code without installing the plugins.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Atto multilanguage plugin
 =========================
 
-![Release](https://img.shields.io/badge/release-v1.10-blue.svg) ![Supported](https://img.shields.io/badge/supported-3.7-green.svg)
+![Release](https://img.shields.io/badge/release-v1.10-blue.svg) ![Supported](https://img.shields.io/badge/supported-3.6%2C%203.7-green.svg)
 
 This plugin will make the creation of multilingual contents on Moodle much more easier with Atto editor.
 
@@ -9,7 +9,7 @@ The plugin is developed to work with [Iñaki Arenaza's multilang2 filter](https:
 
 ## Current version
 
-The latest release is v1.10 (build 2019110600) for Moodle 3.7.
+The latest release is v1.10 (build 2019110600) for Moodle 3.6 and 3.7.
 
 ## Changes from v1.9
  - The Privacy Api has been implemented so that this plugin complies with the new General Data Protection Regulation, effective as of May 25, 2018.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Atto multilanguage plugin
 =========================
 
-![Release](https://img.shields.io/badge/release-v1.9-blue.svg) ![Supported](https://img.shields.io/badge/supported-2.9%2C%203.0%2C%203.1%2C%203.2%2C%203.3%2C%203.4-green.svg)
+![Release](https://img.shields.io/badge/release-v1.10-blue.svg) ![Supported](https://img.shields.io/badge/supported-3.7-green.svg)
 
 This plugin will make the creation of multilingual contents on Moodle much more easier with Atto editor.
 
@@ -9,7 +9,10 @@ The plugin is developed to work with [Iñaki Arenaza's multilang2 filter](https:
 
 ## Current version
 
-The latest release is v1.9 (build 2017102700) for Moodle 2.9, 3.0, 3.1, 3.2, 3.4 and 3.4 (Checkout [v2.9.1.9](https://github.com/iarenaza/moodle-atto_multilang2/releases/tag/v2.9.1.9), [v3.0.1.9](https://github.com/iarenaza/moodle-atto_multilang2/releases/tag/v3.0.1.9), [v3.1.1.9](https://github.com/iarenaza/moodle-atto_multilang2/releases/tag/v3.1.1.9), [v3.2.1.9](https://github.com/iarenaza/moodle-atto_multilang2/releases/tag/v3.2.1.9) and [v3.3.1.9](https://github.com/iarenaza/moodle-atto_multilang2/releases/tag/v3.3.1.9) releases, respectively.
+The latest release is v1.10 (build 2019110600) for Moodle 3.7.
+
+## Changes from v1.9
+ - The Privacy Api has been implemented so that this plugin complies with the new General Data Protection Regulation, effective as of May 25, 2018.
 
 ## Changes from v1.8
  - Added Grunt support files. No we can check Moodle Javascript coding guidelines and minify the plugin code without installing the plugins.

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,48 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Atto text editor multilanguage plugin lib.
+ *
+ * @package   atto_multilang2
+ * @copyright 2019 onwards Kepa Urzelai & Mondragon Unibertsitatea
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace atto_multilang2\privacy;
+ 
+ defined('MOODLE_INTERNAL') || die();
+
+ /**
+ * Privacy Subsystem for atto_multilang2 implementing null_provider.
+ *
+ * @copyright  2019 Kepa Urzelai & Mondragon Unibertsitatea <kepa.urzelaiv@alumni.mondragon.edu>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements
+    // This plugin does not store any personal user data.
+    \core_privacy\local\metadata\null_provider {
+ 
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -23,19 +23,19 @@
  */
 
 namespace atto_multilang2\privacy;
- 
+
  defined('MOODLE_INTERNAL') || die();
 
- /**
- * Privacy Subsystem for atto_multilang2 implementing null_provider.
- *
- * @copyright  2019 Kepa Urzelai & Mondragon Unibertsitatea <kepa.urzelaiv@alumni.mondragon.edu>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+  /**
+  * Privacy Subsystem for atto_multilang2 implementing null_provider.
+  *
+  * @copyright  2019 Kepa Urzelai & Mondragon Unibertsitatea <kepa.urzelaiv@alumni.mondragon.edu>
+  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+  */
 class provider implements
     // This plugin does not store any personal user data.
     \core_privacy\local\metadata\null_provider {
- 
+
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,7 +24,7 @@
 
 namespace atto_multilang2\privacy;
 
- defined('MOODLE_INTERNAL') || die();
+defined('MOODLE_INTERNAL') || die();
 
   /**
   * Privacy Subsystem for atto_multilang2 implementing null_provider.

--- a/lang/en/atto_multilang2.php
+++ b/lang/en/atto_multilang2.php
@@ -28,4 +28,5 @@ $string['highlight_desc'] = 'Visually highlight the multi-language content delim
 $string['customcss'] = 'CSS for delimiters';
 $string['customcss_desc'] = "<br>CSS used to highlight the multi-language content delimiters.
 <p><b>Attention:</b> just put the CSS BODY RULES, excluding the selectors, just as it appears in the default value.</p>";
+$string['other'] = 'Other';
 $string['multilang2:viewlanguagemenu'] = 'View language menu in the editor';

--- a/lang/en/atto_multilang2.php
+++ b/lang/en/atto_multilang2.php
@@ -18,7 +18,7 @@
  * Strings for 'Atto Multilang v2' plugin.
  *
  * @package   atto_multilang2
- * @copyright 2015 onwards Julen Pardo & Mondragon Unibertsitatea
+ * @copyright 2015 onwards Julen Pardo, Kepa Urzelai & Mondragon Unibertsitatea
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -29,3 +29,4 @@ $string['customcss'] = 'CSS for delimiters';
 $string['customcss_desc'] = "<br>CSS used to highlight the multi-language content delimiters.
 <p><b>Attention:</b> just put the CSS BODY RULES, excluding the selectors, just as it appears in the default value.</p>";
 $string['multilang2:viewlanguagemenu'] = 'View language menu in the editor';
+$string['privacy:metadata'] = 'The Multi-Language Content (v2) plugin for the atto editor doesn`t store any personal data';

--- a/lang/en/atto_multilang2.php
+++ b/lang/en/atto_multilang2.php
@@ -29,4 +29,4 @@ $string['customcss'] = 'CSS for delimiters';
 $string['customcss_desc'] = "<br>CSS used to highlight the multi-language content delimiters.
 <p><b>Attention:</b> just put the CSS BODY RULES, excluding the selectors, just as it appears in the default value.</p>";
 $string['multilang2:viewlanguagemenu'] = 'View language menu in the editor';
-$string['privacy:metadata'] = 'The Multi-Language Content (v2) plugin for the atto editor doesn`t store any personal data';
+$string['privacy:metadata'] = 'The Multi-Language Content (v2) plugin for the atto editor does not store any personal data';

--- a/lang/es/atto_multilang2.php
+++ b/lang/es/atto_multilang2.php
@@ -18,7 +18,7 @@
  * Strings for 'Atto Multilang v2' plugin.
  *
  * @package   atto_multilang2
- * @copyright 2015 onwards Julen Pardo & Mondragon Unibertsitatea
+ * @copyright 2015 onwards Julen Pardo, Kepa Urzelai & Mondragon Unibertsitatea
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -28,3 +28,4 @@ $string['highlight_desc'] = 'Destacar visualmente los delimitadores del contenid
 $string['customcss'] = 'CSS para los delimitadores';
 $string['customcss_desc'] = "<br>CSS usado para destacar los delimitadores del contenido multi-idioma.
 <p><b>Atenci&oacute;n:</b> poner solo las EL CUERPO DE LAS REGLAS CSS, excluyendo los selectores, tal y como aparece en el valor por defecto.</p>";
+$string['privacy:metadata'] = 'El plugin Contenido Multi-Idioma (v2) para el editor atto no almacena ningún dato personal';

--- a/lang/eu/atto_multilang2.php
+++ b/lang/eu/atto_multilang2.php
@@ -18,7 +18,7 @@
  * Strings for 'Atto Multilang v2' plugin.
  *
  * @package   atto_multilang2
- * @copyright 2015 onwards Julen Pardo & Mondragon Unibertsitatea
+ * @copyright 2015 onwards Julen Pardo, Kepa Urzelai & Mondragon Unibertsitatea
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -28,3 +28,4 @@ $string['highlight_desc'] = 'Bisualki nabarmendu multi-hizkuntza eduki mugatzail
 $string['customcss'] = 'CSS mugatzaileentzat';
 $string['customcss_desc'] = "<br>Erabilitako CSS-a multi-hizkuntza eduki mugatzaileentzat.
 <p><b>Kontuz:</b> jarri soilik CSS GORPUTZAREN ARAUAK, selektoreak baztertuz, lehenetsitako balorean bezala.</p>";
+$string['privacy:metadata'] = 'Atto editorerako Eduki Eleanitza (v2) pluginak ez ditu datu pertsonalik grodetzen';

--- a/lib.php
+++ b/lib.php
@@ -30,7 +30,9 @@ defined('MOODLE_INTERNAL') || die();
  * @return array The JSON encoding of the installed languages.
  */
 function atto_multilang2_params_for_js() {
-    $languages = json_encode(get_string_manager()->get_list_of_translations());
+    $availablelanguages = get_string_manager()->get_list_of_translations();
+    $availablelanguages['other'] = get_string("other", "atto_multilang2") . " (other)";
+    $languages = json_encode($availablelanguages);
     $capability = get_capability();
     $highlight = (get_config('atto_multilang2', 'highlight') === '1') ? true : false;
     $css = get_config('atto_multilang2', 'customcss');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Moodle",
   "devDependencies": {
     "async": "1.5.2",
-    "eslint": "3.7.1",
+    "eslint": ">=4.18.2",
     "gherkin-lint": "1.1.3",
     "grunt": "1.0.1",
     "grunt-contrib-less": "1.3.0",

--- a/tests/behat/multilang2.feature
+++ b/tests/behat/multilang2.feature
@@ -5,11 +5,23 @@ Feature: Atto multilanguage list
   @javascript
   Scenario: Tag some text with multilang labels
     Given I log in as "admin"
-    And the following config values are set as admin:
-      | toolbar | multilang2 = multilang2, table | editor_atto | # Needed table button, otherwise multilang list doesn't spread out...
-    And I am on homepage
-    And I follow "Profile" in the user menu
-    And I follow "Edit profile"
+    And I navigate to "Atto toolbar settings" node in "Site administration > Plugins > Text editors > Atto HTML editor"
+    And I set the field "Toolbar config" to multiline:
+    """
+      style1 = title, bold, italic
+      list = unorderedlist, orderedlist
+      links = link
+      files = image, media, managefiles
+      style2 = underline, strike, subscript, superscript
+      align = align
+      indent = indent
+      insert = equation, charmap, table, clear
+      undo = undo
+      accessibility = accessibilitychecker, accessibilityhelper
+      other = html, multilang2
+    """
+    And I click on "Save changes" "button"
+    And I open my profile in edit mode
     And I set the field "Description" to "Multilingual content"
     And I select the text in the "Description" Atto editor
     When I click on "Multi-Language Content (v2)" "button"

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version      = 2019110600;         // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release      = 'master - Release v1.10 (Build 2019110600) for Moodle 2.9 or later.';
-$plugin->requires     = 2019052002;        // Required Moodle version.
+$plugin->release      = 'master - Release v1.10 (Build 2019110600) for Moodle 3.6 and 3.7';
+$plugin->requires     = 2018120300;        // Required Moodle version.
 $plugin->component    = 'atto_multilang2'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity     = MATURITY_STABLE;
 $plugin->dependencies = array(

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version      = 2017102700;         // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release      = 'master - Release v1.9 (Build 2017102700) for Moodle 2.9 or later.';
-$plugin->requires     = 2015051100;        // Required Moodle version.
+$plugin->version      = 2019110600;         // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release      = 'master - Release v1.10 (Build 2019110600) for Moodle 2.9 or later.';
+$plugin->requires     = 2019052002;        // Required Moodle version.
 $plugin->component    = 'atto_multilang2'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity     = MATURITY_STABLE;
 $plugin->dependencies = array(


### PR DESCRIPTION
Also, the atto buttons are now the standard ones, with multilang2 additionally.