### PR TITLE
Supporting fallback to 'other'.

### DIFF
--- a/lang/en/atto_multilang2.php
+++ b/lang/en/atto_multilang2.php
@@ -28,4 +28,5 @@ $string['highlight_desc'] = 'Visually highlight the multi-language content delim
 $string['customcss'] = 'CSS for delimiters';
 $string['customcss_desc'] = "<br>CSS used to highlight the multi-language content delimiters.
 <p><b>Attention:</b> just put the CSS BODY RULES, excluding the selectors, just as it appears in the default value.</p>";
+$string['other'] = 'Other';
 $string['multilang2:viewlanguagemenu'] = 'View language menu in the editor';

--- a/lib.php
+++ b/lib.php
@@ -30,7 +30,9 @@ defined('MOODLE_INTERNAL') || die();
  * @return array The JSON encoding of the installed languages.
  */
 function atto_multilang2_params_for_js() {
-    $languages = json_encode(get_string_manager()->get_list_of_translations());
+    $availablelanguages = get_string_manager()->get_list_of_translations();
+    $availablelanguages['other'] = get_string("other", "atto_multilang2") . " (other)";
+    $languages = json_encode($availablelanguages);
     $capability = get_capability();
     $highlight = (get_config('atto_multilang2', 'highlight') === '1') ? true : false;
     $css = get_config('atto_multilang2', 'customcss');


### PR DESCRIPTION
Dear Julen
We worked on this in the Vienna MoodleMootDACH DevCamp. It would be great if you could implement this into your filter.
Note that we submit a pull request for filter_multilang2 as well. (https://github.com/iarenaza/moodle-filter_multilang2/pull/14)
Best, Kathrin, Eva, Mihail and Luca